### PR TITLE
assets registry prefix, conflict crufts

### DIFF
--- a/engine/asset/asset-registry.d.ts
+++ b/engine/asset/asset-registry.d.ts
@@ -9,7 +9,12 @@ declare namespace pc {
     * @property {String} prefix A URL prefix that will be added to all asset loading requests.
     */
     class AssetRegistry {
-        constructor(loader: pc.ResourceLoader)
+        /**
+         * @description A URL prefix that will be added to all asset loading requests.
+         */
+        prefix: string;
+
+        constructor(loader: pc.ResourceLoader);
 
         /**
         * @function

--- a/engine/asset/asset.d.ts
+++ b/engine/asset/asset.d.ts
@@ -1,19 +1,19 @@
 declare namespace pc {
 
-+    const ASSET_ANIMATION: string;
-+    const ASSET_AUDIO: string;
-+    const ASSET_IMAGE: string;
-+    const ASSET_JSON: string;
-+    const ASSET_MODEL: string;
-+    const ASSET_MATERIAL: string;
-+    const ASSET_TEXT: string;
-+    const ASSET_TEXTURE: string;
-+    const ASSET_CUBEMAP: string;
-+    const ASSET_SHADER: string;
-+    const ASSET_CSS: string;
-+    const ASSET_HTML: string;
-+    const ASSET_SCRIPT: string;
-+    const ABSOLUTE_URL: string;
+    const ASSET_ANIMATION: string;
+    const ASSET_AUDIO: string;
+    const ASSET_IMAGE: string;
+    const ASSET_JSON: string;
+    const ASSET_MODEL: string;
+    const ASSET_MATERIAL: string;
+    const ASSET_TEXT: string;
+    const ASSET_TEXTURE: string;
+    const ASSET_CUBEMAP: string;
+    const ASSET_SHADER: string;
+    const ASSET_CSS: string;
+    const ASSET_HTML: string;
+    const ASSET_SCRIPT: string;
+    const ABSOLUTE_URL: string;
 
     /**
     * @name pc.Asset


### PR DESCRIPTION
Looks like a conflict ended up being merged with the
"+" prefixes, which I assume would break things.

Added the `prefix` attribute as per
https://developer.playcanvas.com/en/api/pc.AssetRegistry.html#prefix